### PR TITLE
Fixes installation of the source distribution using pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include closure *.jar
+include README.rst


### PR DESCRIPTION
The source distribution can't be installed using pip. The setup.py tries to open README.txt, but that file isn't included in the tarball. This patch adds it to the manifest so that it will be included in the tarball after running 'python setup.py sdist' again.
