### PR TITLE
Try to use importlib.resources when possible

### DIFF
--- a/closure/__init__.py
+++ b/closure/__init__.py
@@ -23,7 +23,7 @@ def get_importlib_resources_jar():
     file_manager = ExitStack()
     atexit.register(file_manager.close)
     ref = importlib.resources.files(__name__) / "closure.jar"
-    return file_manager.enter_context(importlib.resources.as_file(ref))
+    return str(file_manager.enter_context(importlib.resources.as_file(ref)))
 
 
 def get_pkg_resources_jar():

--- a/closure/__init__.py
+++ b/closure/__init__.py
@@ -1,10 +1,32 @@
 import sys
 import subprocess
-from pkg_resources import resource_filename
+
+try:
+    # use importlib here instead
+    import atexit
+    import importlib.resources
+    from contextlib import ExitStack
+
+    def get_jar_filename():
+        """Return the full path to the Closure Compiler Java archive."""
+        return get_importlib_resources_jar()
+
+except ImportError:
+    from pkg_resources import resource_filename
+
+    def get_jar_filename():
+        """Return the full path to the Closure Compiler Java archive."""
+        return get_pkg_resources_jar()
 
 
-def get_jar_filename():
-    """Return the full path to the Closure Compiler Java archive."""
+def get_importlib_resources_jar():
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files(__name__) / "closure.jar"
+    return file_manager.enter_context(importlib.resources.as_file(ref))
+
+
+def get_pkg_resources_jar():
     return resource_filename(__name__, "closure.jar")
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     long_description=open('README.rst').read(),
     author='Michael Elsdörfer',
     author_email='michael@elsdoerfer.com',
-    version="20191111",
+    version="20231104",
     url="http://pypi.python.org/pypi/closure",
     license='BSD',
     packages=find_packages(),


### PR DESCRIPTION
`importlib.resources` is the post-Python-3.7 standard for accessing resources in the package

Attempt to import that library, and if it is all available, use it according to the atexit cleanup instructions in the migration guide

Fixes: #20 